### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This attribution is not necessary in case of usage (you can paint any artwork yo
 This attribution is not necessary in case of doing screenshot/screenrecording of Krita and have the brushkit visible. 
 
 
-##Installation
+## Installation
 
 2 ways :
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
